### PR TITLE
Add dynamic URL for production vs development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2881,6 +2881,24 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -10066,6 +10084,10 @@
         "codenames-frontend": "0.0.1",
         "nodemon": "^2.0.19",
         "typescript": "^4.7.4"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "packages/eslint-config-custom": {
@@ -10094,6 +10116,7 @@
       "devDependencies": {
         "@stencil/sass": "^1.5.2",
         "@types/jest": "^27.0.3",
+        "cross-env": "^7.0.3",
         "jest": "^27.4.5",
         "jest-cli": "^27.4.5",
         "puppeteer": "^15.4.0",
@@ -12186,6 +12209,7 @@
         "@stencil/sass": "^1.5.2",
         "@types/jest": "^27.0.3",
         "axios": "^0.27.2",
+        "cross-env": "*",
         "jest": "^27.4.5",
         "jest-cli": "^27.4.5",
         "puppeteer": "^15.4.0",
@@ -12297,6 +12321,15 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "build": "turbo run build",
     "serve": "turbo run --filter=*backend* serve",
     "start": "node packages/backend/build/index.js",
+    "deploy": "turbo run deploy",
     "test": "turbo run test",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "frontend": "turbo run --filter=*frontend*",
-    "backend": "turbo run --filter=*backend*",
-    "deploy": "npx gh-pages -d packages/frontend/www/codenames"
+    "backend": "turbo run --filter=*backend*"
   },
   "devDependencies": {
     "eslint-config-custom": "*",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "start": "tsc -w",
-    "serve": "nodemon build/index.js"
+    "serve": "nodemon build/index.js",
+    "deploy": "git push heroku master"
   },
   "keywords": [],
   "author": "",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -20,10 +20,11 @@
   ],
   "scripts": {
     "build": "stencil build --docs",
-    "start": "stencil build --watch --serve",
+    "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec",
     "test.watch": "stencil test --spec --e2e --watchAll",
-    "generate": "stencil generate"
+    "generate": "stencil generate",
+    "deploy": "npx gh-pages -d www/codenames"
   },
   "dependencies": {
     "@stencil/core": "^2.13.0",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@stencil/sass": "^1.5.2",
     "@types/jest": "^27.0.3",
+    "cross-env": "^7.0.3",
     "jest": "^27.4.5",
     "jest-cli": "^27.4.5",
     "puppeteer": "^15.4.0",

--- a/packages/frontend/src/components/codenames-app/codenames-app.tsx
+++ b/packages/frontend/src/components/codenames-app/codenames-app.tsx
@@ -1,6 +1,7 @@
 import { Component, Host, h, Listen, State } from '@stencil/core';
 import { BoardData } from "../../extra/types";
 import { io, Socket } from "socket.io-client";
+import { SERVER_URL } from "../../extra/constants";
 
 @Component({
   tag: 'codenames-app',
@@ -29,7 +30,7 @@ export class CodenamesApp {
    * Stencil lifecycle method `connectedCallback` for `codenames-app` component.
    */
   async connectedCallback(): Promise<void> {
-    this.socket = io("https://bestdotaeu-codenames-backend.herokuapp.com");
+    this.socket = io(SERVER_URL);
     this.socket.on("updateBoard", (boardData: BoardData) => {
       this.boardData = boardData;
     });

--- a/packages/frontend/src/components/codenames-cell/codenames-cell.tsx
+++ b/packages/frontend/src/components/codenames-cell/codenames-cell.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, State, Event, EventEmitter } from "@stencil/core";
+import { Component, Prop, h, State, Event, EventEmitter, Watch } from "@stencil/core";
 import { CellColor, CellMode } from "../../extra/types";
 
 @Component({
@@ -33,6 +33,14 @@ export class CodenamesCell {
   @Prop() revealed?: boolean = false;
 
   /**
+   * Watcher for `revealed` prop.
+   */
+  @Watch("revealed")
+  revealedChanged(): void {
+    this.showSpinner = false;
+  }
+
+  /**
    * Whether to show loading spinner.
    */
   @State() private showSpinner: boolean = false;
@@ -46,7 +54,6 @@ export class CodenamesCell {
    * Stencil lifecycle method `render` for `codenames-cell` component.
    */
   render(): void {
-    this.showSpinner = false;
     return (
       <div
         class={`${this.color} ${this.mode} ${this.revealed ? "revealed" : ""}`}

--- a/packages/frontend/src/extra/constants.ts
+++ b/packages/frontend/src/extra/constants.ts
@@ -1,0 +1,3 @@
+export const SERVER_URL = process.env.NODE_ENV === "development" ?
+  "http://localhost:8080" :
+  "https://bestdotaeu-codenames-backend.herokuapp.com"

--- a/turbo.json
+++ b/turbo.json
@@ -2,8 +2,15 @@
   "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
+      "dependsOn": ["^build"]
+    },
+    "codenames-frontend#build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**"]
+      "outputs": ["dist/**", "www/**"]
+    },
+    "codenames-backend#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["build/**"]
     },
     "lint": {
       "outputs": []
@@ -12,9 +19,11 @@
       "cache": false
     },
     "serve": {
+      "dependsOn": ["build", "^build"],
       "cache": false
     },
     "deploy": {
+      "dependsOn": ["build"],
       "cache": false
     },
     "test": {


### PR DESCRIPTION
Added logic to determine the server URL as either `localhost` or the Heroku production server depending on the environment. Also added a quick fix for the spinner rendering.