### PR TITLE
Add URL parameter to determine 'dev' mode for client app

### DIFF
--- a/packages/frontend/src/components/codenames-app/codenames-app.tsx
+++ b/packages/frontend/src/components/codenames-app/codenames-app.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, h, Listen, State } from '@stencil/core';
 import { BoardData } from "../../extra/types";
 import { io, Socket } from "socket.io-client";
-import { PROD_URL } from "../../extra/constants";
+import { PROD_URL, DEV_URL } from "../../extra/constants";
 
 @Component({
   tag: 'codenames-app',
@@ -30,7 +30,9 @@ export class CodenamesApp {
    * Stencil lifecycle method `connectedCallback` for `codenames-app` component.
    */
   async connectedCallback(): Promise<void> {
-    this.socket = io(PROD_URL);
+    const urlParams = new URLSearchParams(window.location.search);
+    const url = urlParams.get("dev") === "true" ? DEV_URL : PROD_URL;
+    this.socket = io(url);
     this.socket.on("updateBoard", (boardData: BoardData) => {
       this.boardData = boardData;
     });

--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,6 @@
       "cache": false
     },
     "serve": {
-      "dependsOn": ["build", "^build"],
       "cache": false
     },
     "deploy": {


### PR DESCRIPTION
Fixes #28.

Adds a URL parameter called `dev` to the client app to tell it to make requests to the local server instead of the deployed heroku server. This URL can be written like `http://localhost:3333/codenames/?dev=true`.

To test the PR:
- Pull `nels/dev-prod-urls` branch.
- Run `npm run build`.
- Start `npm run serve`.
- Start `npm run frontend start`.
- `http://localhost:3333/codenames/` will open automatically.
- Add the url param `dev=true`, so the url should look like `http://localhost:3333/codenames/?dev=true`.
- Switch between `dev=true` and `dev=false` a few times.
- **The board should change on each switch since the server URL is changing.**