### PR TITLE
Kobi/backend leave room

### DIFF
--- a/packages/backend/code/index.ts
+++ b/packages/backend/code/index.ts
@@ -271,6 +271,26 @@ io.on("connection", (socket) => {
   };
 
   /**
+   * Leaves a room.
+   * @param roomCode
+   * @param username
+   */
+   const leaveRoom = async (roomCode: string, username: string): Promise<void> => {
+    const data: RecursivePartial<Room> & { players: RecursivePartial<PlayerData> } = { players: [] };
+    const room = await mongoGetRoom(roomCode);
+    if (room) {
+      const playerIndex = room.players.findIndex((player) => player.username === username);
+      const player = room.players[playerIndex];
+      if (player !== undefined) {
+        player.mode === Mode.Spymaster ? socket.leave(roomCode + SPYMASTER_SUFFIX) : socket.leave(roomCode + GUESSER_SUFFIX);
+        data.players.splice(playerIndex, 1);
+        console.log(data.players);
+      }
+      await mongoUpdateRoom(roomCode, data);
+    }
+  };
+
+  /**
    * Creates a new room.
    * @param roomCode
    * @param host
@@ -402,6 +422,7 @@ io.on("connection", (socket) => {
   socket.on("becomeGuesser", becomeGuesser);
   socket.on("newGame", newGame);
   socket.on("enterRoom", enterRoom);
+  socket.on("leaveRoom", leaveRoom);
   socket.on("revealCell", revealCell);
   socket.on("joinTeam", joinTeam);
   socket.on("endTurn", endTurn);

--- a/packages/frontend/src/components/codenames-app/codenames-app.tsx
+++ b/packages/frontend/src/components/codenames-app/codenames-app.tsx
@@ -152,7 +152,7 @@ export class CodenamesApp {
    * Request to end the turn.
    */
   private endTurn = (): void => {
-    this.socket.emit("leaveRoom", this.roomCode, this.username);
+    this.socket.emit("endTurn", this.roomCode);
   };
 
   /**

--- a/packages/frontend/src/components/codenames-app/codenames-app.tsx
+++ b/packages/frontend/src/components/codenames-app/codenames-app.tsx
@@ -152,7 +152,7 @@ export class CodenamesApp {
    * Request to end the turn.
    */
   private endTurn = (): void => {
-    this.socket.emit("endTurn", this.roomCode);
+    this.socket.emit("leaveRoom", this.roomCode, this.username);
   };
 
   /**

--- a/packages/frontend/src/extra/types.ts
+++ b/packages/frontend/src/extra/types.ts
@@ -45,6 +45,7 @@ export interface PlayerData {
   mode?: Mode;
   spoiled?: boolean;
   team?: Team;
+  connected?: boolean;
 }
 
 /**


### PR DESCRIPTION
Unsure of the exact implementation of the leave room function do to the use of the merge function in "mongoUpdateRoom". Not sure how to remove data using it.

-  Add backend functionality to facilitate users leaving or being removed from rooms.
-  During server startup the player list in all rooms needs to be updated to empty, as no user would be able to join a room with a username that was present before the server went down. This is due to the fact the backend now disallows multiple usernames in one room explicitly however frontend compliance needs to be updated in tandem.
-  Join room function now emits to client **bool** value based on validity of join request.

