### PR TITLE
Fix bug where invalid moves where being added to turn history.

### DIFF
--- a/packages/backend/code/index.ts
+++ b/packages/backend/code/index.ts
@@ -266,7 +266,7 @@ const revealCell = (roomCode: string, cellIndex: number, username: string): void
     const origTurn = room.turn;
     let gameOver: boolean = false;
 
-    if (player?.team === room.turn && room.scores[Color.Black] === BLACK_WORDS) {
+    if (player?.team === room.turn && room.scores[Color.Black] === BLACK_WORDS && room.scores[Color.Blue] !== 0 && room.scores[Color.Red] !== 0) {
       const cellColor = room.masterBoard[cellIndex].color as Color;
       const scores = findScores(room.masterBoard);
 
@@ -297,16 +297,16 @@ const revealCell = (roomCode: string, cellIndex: number, username: string): void
 
       // Update cell on master board
       room.masterBoard[cellIndex].revealed = true;
-    }
 
-    // Update game for clients
-    updateGame(room);
+      // Update game for clients
+      updateGame(room);
 
-    // Update database
-    await mongoUpdateRoom(room);
-    await mongoHistoryAddTurn(room, room.masterBoard[cellIndex], username, origTurn);
-    if (gameOver) {
-      await mongoHistoryEndGame(room);
+      // Update database
+      await mongoUpdateRoom(room);
+      await mongoHistoryAddTurn(room, room.masterBoard[cellIndex], username, origTurn);
+      if (gameOver) {
+        await mongoHistoryEndGame(room);
+      }
     }
   });
 };


### PR DESCRIPTION
- Moved database and game updating logic into if statement for revealCell so that only valid moves are included in match history. Did not see a reason it needed to be outside unless I am missing something.

- Added check for game over in initial move validity screening, as moves made after the game is over where considered valid previously.
