### PR TITLE
Control loading animation via the server instead of the frontend

### DIFF
--- a/packages/frontend/src/components.d.ts
+++ b/packages/frontend/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { BoardData, Color, GameData, Mode, PlayerData, Requests, Scores } from "./extra/types";
+import { BoardData, Color, GameData, Mode, PlayerData, Scores, Server } from "./extra/types";
 export namespace Components {
     interface CodenamesApp {
     }
@@ -19,9 +19,9 @@ export namespace Components {
          */
         "canGuess": boolean;
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
-        "requests": Requests;
+        "server": Server;
     }
     interface CodenamesButton {
         /**
@@ -47,17 +47,21 @@ export namespace Components {
          */
         "index": number;
         /**
+          * Whether cell is currently loading.
+         */
+        "loading"?: boolean;
+        /**
           * Cell display mode.
          */
         "mode"?: Mode;
         /**
-          * Library of requests that can be made to the server.
-         */
-        "requests": Requests;
-        /**
           * Whether the cell is revealed.
          */
         "revealed"?: boolean;
+        /**
+          * Library of server utilities.
+         */
+        "server": Server;
         /**
           * Word shown in cell.
          */
@@ -69,9 +73,9 @@ export namespace Components {
          */
         "gameData"?: GameData;
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
-        "requests": Requests;
+        "server": Server;
         /**
           * Player data for the user.
          */
@@ -79,13 +83,13 @@ export namespace Components {
     }
     interface CodenamesLandingPage {
         /**
-          * Library of requests that can be made to the server.
-         */
-        "requests": Requests;
-        /**
           * Room code currently entered.
          */
         "roomCode"?: string;
+        /**
+          * Library of server utilities.
+         */
+        "server": Server;
         /**
           * Username currently entered.
          */
@@ -93,7 +97,7 @@ export namespace Components {
     }
     interface CodenamesPanel {
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
         "panelTeam": Color;
         /**
@@ -101,9 +105,9 @@ export namespace Components {
          */
         "players"?: PlayerData[];
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
-        "requests": Requests;
+        "server": Server;
     }
     interface CodenamesScores {
         /**
@@ -198,9 +202,9 @@ declare namespace LocalJSX {
          */
         "canGuess"?: boolean;
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
-        "requests"?: Requests;
+        "server"?: Server;
     }
     interface CodenamesButton {
         /**
@@ -226,17 +230,21 @@ declare namespace LocalJSX {
          */
         "index"?: number;
         /**
+          * Whether cell is currently loading.
+         */
+        "loading"?: boolean;
+        /**
           * Cell display mode.
          */
         "mode"?: Mode;
         /**
-          * Library of requests that can be made to the server.
-         */
-        "requests"?: Requests;
-        /**
           * Whether the cell is revealed.
          */
         "revealed"?: boolean;
+        /**
+          * Library of server utilities.
+         */
+        "server"?: Server;
         /**
           * Word shown in cell.
          */
@@ -248,9 +256,9 @@ declare namespace LocalJSX {
          */
         "gameData"?: GameData;
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
-        "requests"?: Requests;
+        "server"?: Server;
         /**
           * Player data for the user.
          */
@@ -258,13 +266,13 @@ declare namespace LocalJSX {
     }
     interface CodenamesLandingPage {
         /**
-          * Library of requests that can be made to the server.
-         */
-        "requests"?: Requests;
-        /**
           * Room code currently entered.
          */
         "roomCode"?: string;
+        /**
+          * Library of server utilities.
+         */
+        "server"?: Server;
         /**
           * Username currently entered.
          */
@@ -272,7 +280,7 @@ declare namespace LocalJSX {
     }
     interface CodenamesPanel {
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
         "panelTeam"?: Color;
         /**
@@ -280,9 +288,9 @@ declare namespace LocalJSX {
          */
         "players"?: PlayerData[];
         /**
-          * Library of requests that can be made to the server.
+          * Library of server utilities.
          */
-        "requests"?: Requests;
+        "server"?: Server;
     }
     interface CodenamesScores {
         /**

--- a/packages/frontend/src/components.d.ts
+++ b/packages/frontend/src/components.d.ts
@@ -19,6 +19,10 @@ export namespace Components {
          */
         "canGuess": boolean;
         /**
+          * Index of the cell currently loading.
+         */
+        "loadingCellIndex": number;
+        /**
           * Library of server utilities.
          */
         "server": Server;
@@ -201,6 +205,10 @@ declare namespace LocalJSX {
           * Whether it is currently the user's turn to guess.
          */
         "canGuess"?: boolean;
+        /**
+          * Index of the cell currently loading.
+         */
+        "loadingCellIndex"?: number;
         /**
           * Library of server utilities.
          */

--- a/packages/frontend/src/components/codenames-app/codenames-app.tsx
+++ b/packages/frontend/src/components/codenames-app/codenames-app.tsx
@@ -78,7 +78,7 @@ export class CodenamesApp {
   /**
    * Stencil lifecycle method `render` for `codenames-app` component.
    */
-  render(): void {
+  render(): HTMLCodenamesAppElement {
     return (
       <Host>
         <div class="app-container">

--- a/packages/frontend/src/components/codenames-app/codenames-app.tsx
+++ b/packages/frontend/src/components/codenames-app/codenames-app.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, State } from "@stencil/core";
-import { Color, GameData, Requests } from "../../extra/types";
+import { Color, GameData, Server } from "../../extra/types";
 import { io, Socket } from "socket.io-client";
 import { PROD_URL, DEV_URL } from "../../extra/constants";
 
@@ -35,9 +35,9 @@ export class CodenamesApp {
   private socket: Socket;
 
   /**
-   * Library of requests that can be made to the server.
+   * Library of server utilities.
    */
-  private requests: Requests = {};
+  private server: Server = {};
 
   /**
    * Stencil lifecycle method `connectedCallback` for `codenames-app` component.
@@ -55,8 +55,15 @@ export class CodenamesApp {
     const cachedUsername = window.localStorage.getItem("codenamesUsername");
     this.username = cachedUsername ?? "";
 
-    // Setup requests collection
-    this.requests = {
+    this.socket = io(url);
+
+    this.socket.on("updateGame", (gameData: GameData) => {
+      this.gameData = gameData;
+    });
+
+    // Setup server utilities
+    this.server = {
+      socket: this.socket,
       revealCell: this.revealCell,
       enterRoom: this.enterRoom,
       becomeSpymaster: this.becomeSpymaster,
@@ -66,11 +73,6 @@ export class CodenamesApp {
       endTurn: this.endTurn,
       randomizeTeams: this.randomizeTeams
     };
-
-    this.socket = io(url);
-    this.socket.on("updateGame", (gameData: GameData) => {
-      this.gameData = gameData;
-    });
   }
 
   /**
@@ -82,13 +84,13 @@ export class CodenamesApp {
         <div class="app-container">
           {this.showLandingPage ? (
             <codenames-landing-page
-              requests={this.requests}
+              server={this.server}
               roomCode={this.roomCode}
               username={this.username}
             ></codenames-landing-page>
           ) : (
             <codenames-game
-              requests={this.requests}
+              server={this.server}
               gameData={this.gameData}
               userPlayer={this.gameData?.players?.find((player) => player.username === this.username)}
             ></codenames-game>

--- a/packages/frontend/src/components/codenames-board/codenames-board.spec.tsx
+++ b/packages/frontend/src/components/codenames-board/codenames-board.spec.tsx
@@ -6,7 +6,7 @@ describe("codenames-board", () => {
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesBoard],
-      template: () => <codenames-board requests={{}}></codenames-board>
+      template: () => <codenames-board server={{}}></codenames-board>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-board/codenames-board.spec.tsx
+++ b/packages/frontend/src/components/codenames-board/codenames-board.spec.tsx
@@ -1,12 +1,18 @@
 import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
+import { Server } from "../../extra/types";
 import { CodenamesBoard } from "./codenames-board";
 
 describe("codenames-board", () => {
+  const mockServer = {
+    socket: {
+      on: () => {}
+    }
+  } as unknown as Server;
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesBoard],
-      template: () => <codenames-board server={{}}></codenames-board>
+      template: () => <codenames-board server={mockServer}></codenames-board>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-board/codenames-board.tsx
+++ b/packages/frontend/src/components/codenames-board/codenames-board.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, State } from "@stencil/core";
+import { Component, Host, h, Prop } from "@stencil/core";
 import { BoardData, Server } from "../../extra/types";
 
 @Component({
@@ -25,12 +25,12 @@ export class CodenamesBoard {
   /**
    * Index of the cell currently loading.
    */
-  @State() private loadingCellIndex: number = -1;
+  @Prop() loadingCellIndex: number = -1;
 
   /**
    * Stencil lifecycle method `render` for `codenames-board` component.
    */
-  render(): void {
+  render(): HTMLCodenamesBoardElement {
     return (
       <Host>
         {this.boardData?.map((cellData, i) => {

--- a/packages/frontend/src/components/codenames-board/codenames-board.tsx
+++ b/packages/frontend/src/components/codenames-board/codenames-board.tsx
@@ -1,5 +1,5 @@
-import { Component, Host, h, Prop } from "@stencil/core";
-import { BoardData, Requests } from "../../extra/types";
+import { Component, Host, h, Prop, State } from "@stencil/core";
+import { BoardData, Server } from "../../extra/types";
 
 @Component({
   tag: "codenames-board",
@@ -8,9 +8,9 @@ import { BoardData, Requests } from "../../extra/types";
 })
 export class CodenamesBoard {
   /**
-   * Library of requests that can be made to the server.
+   * Library of server utilities.
    */
-  @Prop() requests: Requests;
+  @Prop() server: Server;
 
   /**
    * Board data used to generate the cells.
@@ -23,6 +23,11 @@ export class CodenamesBoard {
   @Prop() canGuess: boolean = false;
 
   /**
+   * Index of the cell currently loading.
+   */
+  @State() private loadingCellIndex: number = -1;
+
+  /**
    * Stencil lifecycle method `render` for `codenames-board` component.
    */
   render(): void {
@@ -31,13 +36,14 @@ export class CodenamesBoard {
         {this.boardData?.map((cellData, i) => {
           return (
             <codenames-cell
-              requests={this.requests}
+              server={this.server}
               index={i}
               word={cellData.word}
               color={cellData.color}
               mode={cellData.mode}
               revealed={cellData.revealed}
               canGuess={this.canGuess}
+              loading={this.loadingCellIndex === i}
             ></codenames-cell>
           );
         }) ?? null}

--- a/packages/frontend/src/components/codenames-board/readme.md
+++ b/packages/frontend/src/components/codenames-board/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property    | Attribute   | Description                                       | Type         | Default     |
-| ----------- | ----------- | ------------------------------------------------- | ------------ | ----------- |
-| `boardData` | --          | Board data used to generate the cells.            | `CellData[]` | `undefined` |
-| `canGuess`  | `can-guess` | Whether it is currently the user's turn to guess. | `boolean`    | `false`     |
-| `server`    | --          | Library of server utilities.                      | `Server`     | `undefined` |
+| Property           | Attribute            | Description                                       | Type         | Default     |
+| ------------------ | -------------------- | ------------------------------------------------- | ------------ | ----------- |
+| `boardData`        | --                   | Board data used to generate the cells.            | `CellData[]` | `undefined` |
+| `canGuess`         | `can-guess`          | Whether it is currently the user's turn to guess. | `boolean`    | `false`     |
+| `loadingCellIndex` | `loading-cell-index` | Index of the cell currently loading.              | `number`     | `-1`        |
+| `server`           | --                   | Library of server utilities.                      | `Server`     | `undefined` |
 
 
 ## Dependencies

--- a/packages/frontend/src/components/codenames-board/readme.md
+++ b/packages/frontend/src/components/codenames-board/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property    | Attribute   | Description                                         | Type         | Default     |
-| ----------- | ----------- | --------------------------------------------------- | ------------ | ----------- |
-| `boardData` | --          | Board data used to generate the cells.              | `CellData[]` | `undefined` |
-| `canGuess`  | `can-guess` | Whether it is currently the user's turn to guess.   | `boolean`    | `false`     |
-| `requests`  | --          | Library of requests that can be made to the server. | `Requests`   | `undefined` |
+| Property    | Attribute   | Description                                       | Type         | Default     |
+| ----------- | ----------- | ------------------------------------------------- | ------------ | ----------- |
+| `boardData` | --          | Board data used to generate the cells.            | `CellData[]` | `undefined` |
+| `canGuess`  | `can-guess` | Whether it is currently the user's turn to guess. | `boolean`    | `false`     |
+| `server`    | --          | Library of server utilities.                      | `Server`     | `undefined` |
 
 
 ## Dependencies

--- a/packages/frontend/src/components/codenames-cell/codenames-cell.spec.tsx
+++ b/packages/frontend/src/components/codenames-cell/codenames-cell.spec.tsx
@@ -7,7 +7,7 @@ describe("codenames-cell", () => {
   it("renders", async () => {
     const { root } = await newSpecPage({
       components: [CodenamesCell],
-      template: () => <codenames-cell requests={{}} word="ivory" color={Color.Blue}></codenames-cell>
+      template: () => <codenames-cell server={{}} word="ivory" color={Color.Blue}></codenames-cell>
     });
     expect(root).toBeTruthy();
     expect(root.tagName).toBe("CODENAMES-CELL");

--- a/packages/frontend/src/components/codenames-cell/codenames-cell.spec.tsx
+++ b/packages/frontend/src/components/codenames-cell/codenames-cell.spec.tsx
@@ -1,13 +1,18 @@
 import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
 import { CodenamesCell } from "./codenames-cell";
-import { Color } from "../../extra/types";
+import { Color, Server } from "../../extra/types";
 
 describe("codenames-cell", () => {
+  const mockServer = {
+    socket: {
+      on: () => {}
+    }
+  } as unknown as Server;
   it("renders", async () => {
     const { root } = await newSpecPage({
       components: [CodenamesCell],
-      template: () => <codenames-cell server={{}} word="ivory" color={Color.Blue}></codenames-cell>
+      template: () => <codenames-cell server={mockServer} word="ivory" color={Color.Blue}></codenames-cell>
     });
     expect(root).toBeTruthy();
     expect(root.tagName).toBe("CODENAMES-CELL");

--- a/packages/frontend/src/components/codenames-cell/codenames-cell.tsx
+++ b/packages/frontend/src/components/codenames-cell/codenames-cell.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, State, Watch } from "@stencil/core";
-import { Color, Mode, Requests } from "../../extra/types";
+import { Color, Mode, Server } from "../../extra/types";
 
 @Component({
   tag: "codenames-cell",
@@ -8,9 +8,9 @@ import { Color, Mode, Requests } from "../../extra/types";
 })
 export class CodenamesCell {
   /**
-   * Library of requests that can be made to the server.
+   * Library of server utilities.
    */
-  @Prop() requests: Requests;
+  @Prop() server: Server;
   /**
    * Index of the cell.
    */
@@ -32,6 +32,11 @@ export class CodenamesCell {
   @Prop() mode?: Mode = Mode.Normal;
 
   /**
+   * Whether cell is currently loading.
+   */
+  @Prop() loading?: boolean = false;
+
+  /**
    * Watcher for `revealed` prop.
    */
   @Watch("mode")
@@ -50,27 +55,9 @@ export class CodenamesCell {
   @Prop() revealed?: boolean = false;
 
   /**
-   * Watcher for `revealed` prop.
-   */
-  @Watch("revealed")
-  revealedChanged(newValue: boolean, oldValue: boolean): void {
-    if (newValue === true && oldValue === false) {
-      this.showSpinner = true;
-      setTimeout(() => {
-        this.showSpinner = false;
-      }, 300);
-    }
-  }
-
-  /**
    * Whether it is currently the user's turn to guess.
    */
   @Prop() canGuess: boolean = false;
-
-  /**
-   * Whether to show loading spinner.
-   */
-  @State() private showSpinner: boolean = false;
 
   /**
    * Whether loading endgame.
@@ -84,11 +71,11 @@ export class CodenamesCell {
     return (
       <div
         class={`${this.color} ${!this.loadingEndgame ? this.mode : ""} ${
-          this.revealed && !this.showSpinner ? "revealed" : ""
+          this.revealed && !this.loading ? "revealed" : ""
         } ${this.canGuess === false ? "no-guess" : ""}`}
         onClick={this.handleRevealCell}
       >
-        {this.showSpinner ? <codenames-spinner></codenames-spinner> : <span>{this.word.toUpperCase()}</span>}
+        {this.loading ? <codenames-spinner></codenames-spinner> : <span>{this.word.toUpperCase()}</span>}
       </div>
     );
   }
@@ -98,10 +85,10 @@ export class CodenamesCell {
    */
   private handleRevealCell = async (): Promise<void> => {
     if (this.canGuess && this.revealed === false) {
-      this.showSpinner = true;
-      this.requests.revealCell(this.index);
+      this.loading = true;
+      this.server.revealCell(this.index);
       setTimeout(() => {
-        this.showSpinner = false;
+        this.loading = false;
       }, 500);
     }
   };

--- a/packages/frontend/src/components/codenames-cell/readme.md
+++ b/packages/frontend/src/components/codenames-cell/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property   | Attribute   | Description                                         | Type                                                   | Default       |
-| ---------- | ----------- | --------------------------------------------------- | ------------------------------------------------------ | ------------- |
-| `canGuess` | `can-guess` | Whether it is currently the user's turn to guess.   | `boolean`                                              | `false`       |
-| `color`    | `color`     | Cell color.                                         | `Color.Black \| Color.Blue \| Color.Gray \| Color.Red` | `Color.Gray`  |
-| `index`    | `index`     | Index of the cell.                                  | `number`                                               | `undefined`   |
-| `mode`     | `mode`      | Cell display mode.                                  | `Mode.Endgame \| Mode.Normal \| Mode.Spymaster`        | `Mode.Normal` |
-| `requests` | --          | Library of requests that can be made to the server. | `Requests`                                             | `undefined`   |
-| `revealed` | `revealed`  | Whether the cell is revealed.                       | `boolean`                                              | `false`       |
-| `word`     | `word`      | Word shown in cell.                                 | `string`                                               | `""`          |
+| Property   | Attribute   | Description                                       | Type                                                   | Default       |
+| ---------- | ----------- | ------------------------------------------------- | ------------------------------------------------------ | ------------- |
+| `canGuess` | `can-guess` | Whether it is currently the user's turn to guess. | `boolean`                                              | `false`       |
+| `color`    | `color`     | Cell color.                                       | `Color.Black \| Color.Blue \| Color.Gray \| Color.Red` | `Color.Gray`  |
+| `index`    | `index`     | Index of the cell.                                | `number`                                               | `undefined`   |
+| `loading`  | `loading`   | Whether cell is currently loading.                | `boolean`                                              | `false`       |
+| `mode`     | `mode`      | Cell display mode.                                | `Mode.Endgame \| Mode.Normal \| Mode.Spymaster`        | `Mode.Normal` |
+| `revealed` | `revealed`  | Whether the cell is revealed.                     | `boolean`                                              | `false`       |
+| `server`   | --          | Library of server utilities.                      | `Server`                                               | `undefined`   |
+| `word`     | `word`      | Word shown in cell.                               | `string`                                               | `""`          |
 
 
 ## Dependencies

--- a/packages/frontend/src/components/codenames-game/codenames-game.spec.tsx
+++ b/packages/frontend/src/components/codenames-game/codenames-game.spec.tsx
@@ -6,7 +6,7 @@ describe("codenames-game", () => {
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesGame],
-      template: () => <codenames-game requests={{}}></codenames-game>
+      template: () => <codenames-game server={{}}></codenames-game>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-game/codenames-game.spec.tsx
+++ b/packages/frontend/src/components/codenames-game/codenames-game.spec.tsx
@@ -1,12 +1,18 @@
 import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
+import { Server } from "../../extra/types";
 import { CodenamesGame } from "./codenames-game";
 
 describe("codenames-game", () => {
+  const mockServer = {
+    socket: {
+      on: () => {}
+    }
+  } as unknown as Server;
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesGame],
-      template: () => <codenames-game server={{}}></codenames-game>
+      template: () => <codenames-game server={mockServer}></codenames-game>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-game/codenames-game.tsx
+++ b/packages/frontend/src/components/codenames-game/codenames-game.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State, Watch } from "@stencil/core";
 import { isEqual } from "lodash";
-import { Color, GameData, Mode, PlayerData, Requests } from "../../extra/types";
+import { Color, GameData, Mode, PlayerData, Server } from "../../extra/types";
 
 @Component({
   tag: "codenames-game",
@@ -9,9 +9,9 @@ import { Color, GameData, Mode, PlayerData, Requests } from "../../extra/types";
 })
 export class CodenamesGame {
   /**
-   * Library of requests that can be made to the server.
+   * Library of server utilities.
    */
-  @Prop() requests: Requests;
+  @Prop() server: Server;
 
   /**
    * Game data used to populate values on the board and UI.
@@ -58,12 +58,12 @@ export class CodenamesGame {
   render(): void {
     return (
       <Host>
-        <codenames-panel requests={this.requests} panelTeam={Color.Blue} players={this.gameData?.players}>
+        <codenames-panel server={this.server} panelTeam={Color.Blue} players={this.gameData?.players}>
           <codenames-button
             class={this.userPlayer?.team !== Color.Blue ? "" : "hidden"}
             slot="list-button"
             color={Color.Blue}
-            onClick={() => this.requests.joinTeam(Color.Blue)}
+            onClick={() => this.server.joinTeam(Color.Blue)}
           >
             <span>Join {Color.Blue}</span>
           </codenames-button>
@@ -74,10 +74,10 @@ export class CodenamesGame {
           >
             <span>Spymaster 👁</span>
           </codenames-button>
-          <codenames-button slot="footer-button" onClick={this.requests.randomizeTeams}>
+          <codenames-button slot="footer-button" onClick={this.server.randomizeTeams}>
             <span>Randomize teams ⚄</span>
           </codenames-button>
-          <codenames-button slot="footer-button" onClick={this.requests.newGame}>
+          <codenames-button slot="footer-button" onClick={this.server.newGame}>
             <span>New game →</span>
           </codenames-button>
         </codenames-panel>
@@ -85,25 +85,25 @@ export class CodenamesGame {
         <div>
           <codenames-scores scores={this.gameData?.scores} turn={this.gameData?.turn}></codenames-scores>
           <codenames-board
-            requests={this.requests}
+            server={this.server}
             boardData={this.gameData?.board}
             canGuess={this.canGuess}
           ></codenames-board>
         </div>
 
-        <codenames-panel requests={this.requests} panelTeam={Color.Red} players={this.gameData?.players}>
+        <codenames-panel server={this.server} panelTeam={Color.Red} players={this.gameData?.players}>
           <codenames-button
             class={this.userPlayer?.team !== Color.Red ? "" : "hidden"}
             slot="list-button"
             color={Color.Red}
-            onClick={() => this.requests.joinTeam(Color.Red)}
+            onClick={() => this.server.joinTeam(Color.Red)}
           >
             <span>Join {Color.Red}</span>
           </codenames-button>
           <codenames-button
             class={this.canGuess ? "" : "hidden"}
             slot="footer-button"
-            onClick={() => this.requests.endTurn()}
+            onClick={() => this.server.endTurn()}
           >
             <span>End turn ✓</span>
           </codenames-button>
@@ -117,9 +117,9 @@ export class CodenamesGame {
    */
   private spymasterToggle = (): void => {
     if (this.userPlayer?.mode === Mode.Spymaster) {
-      this.requests.becomeGuesser();
+      this.server.becomeGuesser();
     } else {
-      this.requests.becomeSpymaster();
+      this.server.becomeSpymaster();
     }
   };
 

--- a/packages/frontend/src/components/codenames-game/readme.md
+++ b/packages/frontend/src/components/codenames-game/readme.md
@@ -8,7 +8,7 @@
 | Property     | Attribute | Description                                            | Type         | Default     |
 | ------------ | --------- | ------------------------------------------------------ | ------------ | ----------- |
 | `gameData`   | --        | Game data used to populate values on the board and UI. | `GameData`   | `undefined` |
-| `requests`   | --        | Library of requests that can be made to the server.    | `Requests`   | `undefined` |
+| `server`     | --        | Library of server utilities.                           | `Server`     | `undefined` |
 | `userPlayer` | --        | Player data for the user.                              | `PlayerData` | `undefined` |
 
 

--- a/packages/frontend/src/components/codenames-landing-page/codenames-landing-page.spec.tsx
+++ b/packages/frontend/src/components/codenames-landing-page/codenames-landing-page.spec.tsx
@@ -1,12 +1,18 @@
 import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
+import { Server } from "../../extra/types";
 import { CodenamesLandingPage } from "./codenames-landing-page";
 
 describe("codenames-landing-page", () => {
+  const mockServer = {
+    socket: {
+      on: () => {}
+    }
+  } as unknown as Server;
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesLandingPage],
-      template: () => <codenames-landing-page server={{}}></codenames-landing-page>
+      template: () => <codenames-landing-page server={mockServer}></codenames-landing-page>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-landing-page/codenames-landing-page.spec.tsx
+++ b/packages/frontend/src/components/codenames-landing-page/codenames-landing-page.spec.tsx
@@ -6,7 +6,7 @@ describe("codenames-landing-page", () => {
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesLandingPage],
-      template: () => <codenames-landing-page requests={{}}></codenames-landing-page>
+      template: () => <codenames-landing-page server={{}}></codenames-landing-page>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-landing-page/codenames-landing-page.tsx
+++ b/packages/frontend/src/components/codenames-landing-page/codenames-landing-page.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, State } from "@stencil/core";
-import { Requests } from "../../extra/types";
+import { Server } from "../../extra/types";
 
 @Component({
   tag: "codenames-landing-page",
@@ -8,9 +8,9 @@ import { Requests } from "../../extra/types";
 })
 export class CodenamesLandingPage {
   /**
-   * Library of requests that can be made to the server.
+   * Library of server utilities.
    */
-  @Prop() requests: Requests;
+  @Prop() server: Server;
 
   /**
    * Username currently entered.
@@ -50,7 +50,7 @@ export class CodenamesLandingPage {
             value={this.username}
             required={true}
             maxLength={10}
-            ref={element => {
+            ref={(element) => {
               this.usernameInput = element;
             }}
           />
@@ -61,7 +61,7 @@ export class CodenamesLandingPage {
             value={this.roomCode}
             required={true}
             maxLength={10}
-            ref={element => {
+            ref={(element) => {
               this.roomCodeInput = element;
             }}
           />
@@ -80,7 +80,7 @@ export class CodenamesLandingPage {
     this.roomCode = this.roomCodeInput.value;
 
     if (this.username !== "" && this.roomCode !== "") {
-      this.requests.enterRoom(this.roomCode, this.username);
+      this.server.enterRoom(this.roomCode, this.username);
     } else {
       this.message = "Please fill out both fields.";
     }

--- a/packages/frontend/src/components/codenames-landing-page/readme.md
+++ b/packages/frontend/src/components/codenames-landing-page/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property   | Attribute   | Description                                         | Type       | Default     |
-| ---------- | ----------- | --------------------------------------------------- | ---------- | ----------- |
-| `requests` | --          | Library of requests that can be made to the server. | `Requests` | `undefined` |
-| `roomCode` | `room-code` | Room code currently entered.                        | `string`   | `""`        |
-| `username` | `username`  | Username currently entered.                         | `string`   | `""`        |
+| Property   | Attribute   | Description                  | Type     | Default     |
+| ---------- | ----------- | ---------------------------- | -------- | ----------- |
+| `roomCode` | `room-code` | Room code currently entered. | `string` | `""`        |
+| `server`   | --          | Library of server utilities. | `Server` | `undefined` |
+| `username` | `username`  | Username currently entered.  | `string` | `""`        |
 
 
 ## Dependencies

--- a/packages/frontend/src/components/codenames-panel/codenames-panel.spec.tsx
+++ b/packages/frontend/src/components/codenames-panel/codenames-panel.spec.tsx
@@ -1,13 +1,18 @@
 import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
-import { Color } from "../../extra/types";
+import { Color, Server } from "../../extra/types";
 import { CodenamesPanel } from "./codenames-panel";
 
 describe("codenames-panel", () => {
+  const mockServer = {
+    socket: {
+      on: () => {}
+    }
+  } as unknown as Server;
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesPanel],
-      template: () => <codenames-panel server={{}} panelTeam={Color.Blue}></codenames-panel>
+      template: () => <codenames-panel server={mockServer} panelTeam={Color.Blue}></codenames-panel>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-panel/codenames-panel.spec.tsx
+++ b/packages/frontend/src/components/codenames-panel/codenames-panel.spec.tsx
@@ -7,7 +7,7 @@ describe("codenames-panel", () => {
   it("renders", async () => {
     const page = await newSpecPage({
       components: [CodenamesPanel],
-      template: () => <codenames-panel requests={{}} panelTeam={Color.Blue}></codenames-panel>
+      template: () => <codenames-panel server={{}} panelTeam={Color.Blue}></codenames-panel>
     });
     expect(page.root).toBeTruthy();
   });

--- a/packages/frontend/src/components/codenames-panel/codenames-panel.tsx
+++ b/packages/frontend/src/components/codenames-panel/codenames-panel.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { Color, Mode, PlayerData, Requests } from "../../extra/types";
+import { Color, Mode, PlayerData, Server } from "../../extra/types";
 
 @Component({
   tag: "codenames-panel",
@@ -8,12 +8,12 @@ import { Color, Mode, PlayerData, Requests } from "../../extra/types";
 })
 export class CodenamesPanel {
   /**
-   * Library of requests that can be made to the server.
+   * Library of server utilities.
    */
-  @Prop() requests: Requests;
+  @Prop() server: Server;
 
   /**
-   * Library of requests that can be made to the server.
+   * Library of server utilities.
    */
   @Prop() panelTeam: Color;
 
@@ -29,7 +29,7 @@ export class CodenamesPanel {
     return (
       <Host class={this.panelTeam}>
         <div class="player-list">
-          {this.players?.map(player => {
+          {this.players?.map((player) => {
             return this.isOnTeam(player) ? this.getNameElement(player) : null;
           })}
           <div class="list-button-container">

--- a/packages/frontend/src/components/codenames-panel/readme.md
+++ b/packages/frontend/src/components/codenames-panel/readme.md
@@ -5,11 +5,11 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                         | Type                                                   | Default     |
-| ----------- | ------------ | --------------------------------------------------- | ------------------------------------------------------ | ----------- |
-| `panelTeam` | `panel-team` | Library of requests that can be made to the server. | `Color.Black \| Color.Blue \| Color.Gray \| Color.Red` | `undefined` |
-| `players`   | --           | All players in the game.                            | `PlayerData[]`                                         | `undefined` |
-| `requests`  | --           | Library of requests that can be made to the server. | `Requests`                                             | `undefined` |
+| Property    | Attribute    | Description                  | Type                                                   | Default     |
+| ----------- | ------------ | ---------------------------- | ------------------------------------------------------ | ----------- |
+| `panelTeam` | `panel-team` | Library of server utilities. | `Color.Black \| Color.Blue \| Color.Gray \| Color.Red` | `undefined` |
+| `players`   | --           | All players in the game.     | `PlayerData[]`                                         | `undefined` |
+| `server`    | --           | Library of server utilities. | `Server`                                               | `undefined` |
 
 
 ## Dependencies

--- a/packages/frontend/src/components/codenames-scores/codenames-scores.tsx
+++ b/packages/frontend/src/components/codenames-scores/codenames-scores.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Watch, State } from "@stencil/core";
+import { Component, Host, h, Prop } from "@stencil/core";
 import { Color, Scores } from "../../extra/types";
 
 @Component({
@@ -18,39 +18,17 @@ export class CodenamesScores {
   @Prop() turn?: Color;
 
   /**
-   * Watcher for data props.
-   */
-  @Watch("scores")
-  @Watch("turn")
-  dataChanged(): void {
-    this.waitForCellSpinner = true;
-    setTimeout(() => {
-      this.waitForCellSpinner = false;
-    }, 300);
-  }
-
-  /**
-   * Will be `true` while waiting for a cell spinner to finish.
-   */
-  @State() private waitForCellSpinner: boolean = false;
-
-  /**
-   * Stencil lifecycle method `componentShouldUpdate` for `codenames-scores` component.
-   */
-  componentShouldUpdate(): boolean {
-    return this.waitForCellSpinner === false;
-  }
-
-  /**
    * Stencil lifecycle method `render` for `codenames-scores` component.
    */
-  render(): void {
+  render(): HTMLCodenamesScoresElement {
     return (
       <Host>
         <div class="scores-container">
           <div class={Color.Blue + " turn-text"}>{this.turn === Color.Blue ? "← Blue's turn" : ""}</div>
           <div>
-            <span class={Color.Blue}>{this.scores?.[Color.Blue] ?? "?"}</span> - <span class={Color.Red}>{this.scores?.[Color.Red] ?? "?"}</span>
+            <span class={Color.Blue}>{this.scores?.[Color.Blue] ?? "?"}</span>
+            {" - "}
+            <span class={Color.Red}>{this.scores?.[Color.Red] ?? "?"}</span>
           </div>
           <div class={Color.Red + " turn-text"}>{this.turn === Color.Red ? "Red's turn →" : ""}</div>
         </div>

--- a/packages/frontend/src/extra/types.ts
+++ b/packages/frontend/src/extra/types.ts
@@ -1,3 +1,4 @@
+import { Socket } from "socket.io-client";
 // @ts-ignore
 import { CodenamesApp } from "../components/codenames-app/codenames-app";
 
@@ -66,9 +67,13 @@ export interface GameData {
 }
 
 /**
- * Library of requests that can be made to the server.
+ * Library of server utilities.
  */
-export interface Requests {
+export interface Server {
+  /**
+   * @see {@link CodenamesApp.socket}
+   */
+  socket?: Socket;
   /**
    * @see {@link CodenamesApp.revealCell}
    */


### PR DESCRIPTION
Server will now communicate which cell is being loaded. Board state will not be revealed (it won't even render the update) until the loading state has been cleared by the server (plus a 0.3 second delay for aesthetics). 

Bonus: clicking a cell while another one is loading is now blocked at the UI level. This makes potential "spam click" bugs less of a concern.