### PR TITLE
Fix: Only reveal a cell if it hasn't already been revealed

### DIFF
--- a/packages/frontend/src/components/codenames-app/codenames-app.tsx
+++ b/packages/frontend/src/components/codenames-app/codenames-app.tsx
@@ -61,6 +61,10 @@ export class CodenamesApp {
       this.gameData = gameData;
     });
 
+    this.socket.on("disconnect", () => {
+      console.log("Socket disconnected");
+    });
+
     // Setup server utilities
     this.server = {
       socket: this.socket,


### PR DESCRIPTION
Adds a conditional to prevent revealing a cell if it has already been revealed. Also improved the logic by which the new scores are calculated to hopefully make a logic error less likely.

Extra: added server and client console logs to say when a socket disconnects.